### PR TITLE
Extract an abstract queue mover

### DIFF
--- a/lib/transfer_jobs.rb
+++ b/lib/transfer_jobs.rb
@@ -3,6 +3,7 @@ module TransferJobs
   require 'transfer_jobs/multi_queue_mover'
   require 'transfer_jobs/redis_job_set'
   require 'transfer_jobs/util'
+  require 'transfer_jobs/queue_mover'
 
   require 'transfer_jobs/railtie' if defined?(Rails)
 end

--- a/lib/transfer_jobs/queue_mover.rb
+++ b/lib/transfer_jobs/queue_mover.rb
@@ -1,15 +1,20 @@
-# frozen_string_literal: true
 module TransferJobs
   class QueueMover
-    # TODO(zen): expose batch api in Status, Locking, LockQueue and use that instead
     attr_reader :source, :dest, :logger, :progress
-    cattr_accessor :shutdown
 
     def initialize(source:, dest:, logger:, progress:)
       @source = source
       @dest = dest
       @logger = logger
       @progress = progress
+    end
+
+        def self.shutdown=(bool)
+      @shutdown = bool
+    end
+
+    def self.shutdown
+      @shutdown
     end
 
     def transfer(&filter)
@@ -40,118 +45,19 @@ module TransferJobs
       end
 
       logger.info "Finished recovering single queue. queue_key=#{source.key}" \
-        " num_moved=#{num_moved} num_dropped=#{num_dropped}"
+      " num_moved=#{num_moved} num_dropped=#{num_dropped}"
       num_moved
     rescue StopIteration, Interrupt
       logger.error "Transfer of queue '#{@source.key}' was stopped" \
-        " after transferring #{num_moved} jobs to the target redis"
+      " after transferring #{num_moved} jobs to the target redis"
       raise
     end
 
-    def move_batch_to_dest(jobs_to_move)
-      locking_jobs = jobs_to_move.select { |job, _| job.try :lock_key }
+    # This method provides the functionality to actually move a batch of jobs to the destination redis
+    # This includes functionality like acquiring and releasing locks.
 
-      lock_queue_jobs = locking_jobs.select { |job, _| job.is_a?(BackgroundQueue::LockQueue) }
-      recover_lock_queues(lock_queue_jobs)
-
-      release_locks_in_source(locking_jobs)
-      locked_jobs = acquire_locks_in_dest(locking_jobs)
-
-      failed_to_lock = locking_jobs - locked_jobs
-      jobs_to_append = jobs_to_move - failed_to_lock
-
-      dest.append(jobs_to_append)
-      recover_job_status(jobs_to_append)
-
-      [jobs_to_append.size, failed_to_lock.size]
-    end
-
-    private
-
-    def with_queue_redis(queue)
-      old = Resque.redis
-      old_bq = BackgroundQueue.redis
-      BackgroundQueue.redis = queue.redis.redis
-      Resque.redis = queue.redis
-      yield
-    ensure
-      BackgroundQueue.redis = old_bq
-      Resque.redis = old
-    end
-
-    def recover_lock_queues(lock_queue_jobs)
-      lock_queue_jobs.each do |job, _|
-        source_lock_queue = with_queue_redis(source) do
-          job.lock_queue_instance
-        end
-
-        dest_lock_queue = with_queue_redis(dest) do
-          job.lock_queue_instance
-        end
-
-        source_lock_queue.rename("#{job.lock_queue_key}:recovery")
-
-        source_lock_queue.each do |queue_job|
-          dest_lock_queue.push([queue_job].to_json)
-        end
-      end
-    end
-
-    def acquire_locks_in_dest(jobs)
-      jobs.select do |job, _|
-        lock = job.send(:build_lock, dest.redis)
-
-        if lock.acquire(job.lock_timeout, fallback: RedisLocking::Lock::NO_FALLBACK)
-          true
-        else
-          logger.warn "Dropping job_id=#{job.job_id} with lock owned by other_job_id=#{lock.owner_token}"
-          false
-        end
-      end
-    end
-
-    def release_locks_in_source(jobs)
-      jobs.each do |job, _|
-        lock = job.send(:build_lock, source.redis)
-        lock.have_lock = true
-        lock.release
-      end
-    end
-
-    # TODO(zen): Push this into the Status::Indexed. Add support for batch writes to Status
-    def recover_job_status(jobs)
-      jobs = jobs.select { |job, _| job.is_a?(BackgroundQueue::Status) }.map { |job, _| job }
-      return if jobs.empty?
-
-      job_status = BackgroundQueue::Status.fetch_multi(jobs.map(&:job_id), redis: source.redis.redis)
-
-      jobs_by_shop = jobs.group_by(&:shop_id)
-
-      jobs_by_shop.each do |shop_id, shop_jobs|
-        dest.redis.redis.pipelined do
-          shop_jobs.each do |job|
-            BackgroundQueue::Status.write(
-              job.job_id,
-              job_status[job.job_id],
-              expires_in: job.class.job_status_tll,
-              redis: dest.redis.redis,
-            )
-          end
-        end
-
-        recover_indexed_job_status(shop_id, shop_jobs)
-      end
-    end
-
-    def recover_indexed_job_status(shop_id, jobs)
-      indexed_jobs = jobs.select { |job| job.is_a?(BackgroundQueue::Status::Indexed) }
-
-      indexed_jobs.group_by(&:class).each do |job_class, class_jobs|
-        job_ids = class_jobs.map(&:job_id)
-
-        index = job_class.index_for_shop_id(shop_id)
-        index.add(job_ids, expires_at: Time.now.to_i + job_class.job_status_tll, gc: false)
-      end
+    def move_batch_to_dest
+      raise NotImplementedError
     end
   end
 end


### PR DESCRIPTION
I extracted a common base class for the `ResqueMover` and `SidekiqMover` classes. This contains the 'flow' of moving a queue and delegates the actual _moving_ to methods that are overwritten by subclasses. It'll also let us delete the `ResqueMover` class from the gem because the current one is very shopify specific and would be hard to make useful in a broader situation. 
  